### PR TITLE
Enable GHS and USD payments on integrations

### DIFF
--- a/1.5.x/upload/catalog/controller/payment/paystack.php
+++ b/1.5.x/upload/catalog/controller/payment/paystack.php
@@ -25,6 +25,7 @@ class ControllerPaymentPaystack extends Controller
             $this->data['ref'] = uniqid('' . $this->session->data['order_id'] . '-');
             $this->data['amount'] = intval($order_info['total'] * 100);
             $this->data['email'] = $order_info['email'];
+            $this->data['currency'] = $order_info['currency_code'];
             $this->data['callback'] = $this->url->link('payment/paystack/callback', 'trxref=' . rawurlencode($this->data['ref']), 'SSL');
  
             if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/payment/paystack.tpl')) {
@@ -45,12 +46,13 @@ class ControllerPaymentPaystack extends Controller
             $skey = $this->config->get('paystack_test_secret');
         }
 
-        $context = stream_context_create(array(
+        $context = stream_context_create(
+            array(
             'http'=>array(
               'method'=>"GET",
               'header'=>"Authorization: Bearer " .  $skey,
             )
-          )
+            )
         );
         $url = 'https://api.paystack.co/transaction/verify/'. rawurlencode($reference);
         $request = file_get_contents($url, false, $context);

--- a/1.5.x/upload/catalog/model/payment/paystack.php
+++ b/1.5.x/upload/catalog/model/payment/paystack.php
@@ -17,8 +17,12 @@ class ModelPaymentPaystack extends Model
             $status = false;
         } 
 
-        // Paystack Only switches NGN for now
-        if ($status && (strtoupper($this->currency->getCode())!=='NGN')) {
+        // Paystack Only switches NGN, GHS and USD for now
+        if ($status 
+            && ((strtoupper($this->currency->getCode())!=='NGN')
+            || (strtoupper($this->config->getCode())!=='GHS')
+            || (strtoupper($this->config->getCode())!=='USD'))
+        ) {
             $status = false;
         }
         

--- a/1.5.x/upload/catalog/view/theme/default/template/payment/paystack.tpl
+++ b/1.5.x/upload/catalog/view/theme/default/template/payment/paystack.tpl
@@ -17,6 +17,7 @@
       key: '<?php echo $key; ?>',
       email: '<?php echo $email; ?>',
       amount: <?php echo $amount; ?>,
+      currency: '<?php echo $currency; ?>',
       ref: '<?php echo $ref; ?>',
       callback: function(response){
           window.location.href='<?php echo html_entity_decode($callback); ?>';

--- a/2.2.x/upload/catalog/controller/payment/paystack.php
+++ b/2.2.x/upload/catalog/controller/payment/paystack.php
@@ -25,6 +25,7 @@ class ControllerPaymentPaystack extends Controller
             $data['ref'] = uniqid('' . $this->session->data['order_id'] . '-');
             $data['amount'] = intval($order_info['total'] * 100);
             $data['email'] = $order_info['email'];
+            $data['currency'] = $order_info['currency_code'];
             $data['callback'] = $this->url->link('payment/paystack/callback', 'trxref=' . rawurlencode($data['ref']), 'SSL');
 
             if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/payment/paystack.tpl')) {
@@ -44,12 +45,13 @@ class ControllerPaymentPaystack extends Controller
             $skey = $this->config->get('paystack_test_secret');
         }
 
-        $context = stream_context_create(array(
-            'http'=>array(
-              'method'=>"GET",
-              'header'=>"Authorization: Bearer " .  $skey,
+        $context = stream_context_create(
+            array(
+                'http'=>array(
+                'method'=>"GET",
+                'header'=>"Authorization: Bearer " .  $skey,
+                )
             )
-          )
         );
         $url = 'https://api.paystack.co/transaction/verify/'. rawurlencode($reference);
         $request = file_get_contents($url, false, $context);

--- a/2.2.x/upload/catalog/model/payment/paystack.php
+++ b/2.2.x/upload/catalog/model/payment/paystack.php
@@ -24,8 +24,12 @@ class ModelPaymentPaystack extends Model
             $status = false;
         }
 
-        // Paystack Only switches NGN for now
-        if ($status && (strtoupper($this->config->get('config_currency'))!=='NGN')) {
+        // Paystack only switches NGN, GHS and USD for now
+        if ($status 
+            && ((strtoupper($this->config->get('config_currency'))!=='NGN')
+            || (strtoupper($this->config->get('config_currency'))!=='GHS')
+            || (strtoupper($this->config->get('config_currency'))!=='USD'))
+        ) {
             $status = false;
         }
 

--- a/2.2.x/upload/catalog/view/theme/default/template/payment/paystack.tpl
+++ b/2.2.x/upload/catalog/view/theme/default/template/payment/paystack.tpl
@@ -16,6 +16,7 @@
       key: '<?php echo $key; ?>',
       email: '<?php echo $email; ?>',
       amount: <?php echo $amount; ?>,
+      currency: '<?php echo $currency; ?>',
       ref: '<?php echo $ref; ?>',
       callback: function(response){
           window.location.href='<?php echo html_entity_decode($callback); ?>';

--- a/2.3.x/upload/catalog/controller/extension/payment/paystack.php
+++ b/2.3.x/upload/catalog/controller/extension/payment/paystack.php
@@ -1,6 +1,7 @@
 <?php
-class ControllerExtensionPaymentPaystack extends Controller {
-	public function index()
+class ControllerExtensionPaymentPaystack extends Controller
+{
+    public function index()
     {
         $this->language->load('extension/payment/paystack');
 
@@ -24,6 +25,7 @@ class ControllerExtensionPaymentPaystack extends Controller {
             $data['ref'] = uniqid('' . $this->session->data['order_id'] . '-');
             $data['amount'] = intval($order_info['total'] * 100);
             $data['email'] = $order_info['email'];
+            $data['currency'] = $order_info['currency_code'];
             $data['callback'] = $this->url->link('extension/payment/paystack/callback', 'trxref=' . rawurlencode($data['ref']), 'SSL');
 
             if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/payment/paystack.tpl')) {
@@ -43,59 +45,18 @@ class ControllerExtensionPaymentPaystack extends Controller {
             $skey = $this->config->get('paystack_test_secret');
         }
 
-        $context = stream_context_create(array(
-            'http'=>array(
-              'method'=>"GET",
-              'header'=>"Authorization: Bearer " .  $skey,
+        $context = stream_context_create(
+            array(
+                'http'=>array(
+                    'method'=>"GET",
+                    'header'=>"Authorization: Bearer " .  $skey,
+                )
             )
-          )
         );
         $url = 'https://api.paystack.co/transaction/verify/'. rawurlencode($reference);
         $request = file_get_contents($url, false, $context);
         return json_decode($request, true);
     }
-    // protected function query_api_transaction_verify($reference)
-    // {
-    //     $url = 'https://api.paystack.co/transaction/verify/' . urlencode($reference);
-    //     $data = array();
-        
-    //     if ($this->config->get('paystack_live')) {
-    //         $skey = $this->config->get('paystack_live_secret');
-    //     } else {
-    //         $skey = $this->config->get('paystack_test_secret');
-    //     }
-
-    //     //open connection
-    //     $ch = curl_init();
-
-    //     //set the url, and the header
-    //     curl_setopt($ch, CURLOPT_URL, $url);
-    //     curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-
-    //     // Paystack's servers require TLSv1.2
-    //     // Force CURL to use this
-    //     if (!defined('CURL_SSLVERSION_TLSV1_2')) {
-    //         define('CURL_SSLVERSION_TLSV1_2', 6);
-    //     }
-    //     curl_setopt($ch, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSV1_2);
-
-    //     curl_setopt(
-    //         $ch, CURLOPT_HTTPHEADER, [
-    //         'Authorization: Bearer ' . $skey]
-    //     );
-
-    //     //execute post
-    //     $result = curl_exec($ch);
-
-    //     //close connection
-    //     curl_close($ch);
-
-    //     if ($result) {
-    //         $data = json_decode($result, true);
-    //     }
-        
-    //     return $data;
-    // }
 
     private function redir_and_die($url, $onlymeta = false)
     {
@@ -114,7 +75,7 @@ class ControllerExtensionPaymentPaystack extends Controller {
             // order id is what comes before the first dash in trxref
             $order_id = substr($trxref, 0, strpos($trxref, '-'));
             // if no dash were in transation reference, we will have an empty order_id
-            if(!$order_id) {
+            if (!$order_id) {
                 $order_id = 0;
             }
 

--- a/2.3.x/upload/catalog/model/payment/paystack.php
+++ b/2.3.x/upload/catalog/model/payment/paystack.php
@@ -24,8 +24,12 @@ class ModelPaymentPaystack extends Model
             $status = false;
         }
 
-        // Paystack Only switches NGN for now
-        if ($status && (strtoupper($this->config->get('config_currency'))!=='NGN')) {
+        // Paystack only switches NGN, GHS and USD for now
+        if ($status 
+            && ((strtoupper($this->config->get('config_currency'))!=='NGN')
+            || (strtoupper($this->config->get('config_currency'))!=='GHS')
+            || (strtoupper($this->config->get('config_currency'))!=='USD'))
+            ) {
             $status = false;
         }
 

--- a/2.3.x/upload/catalog/view/theme/default/template/payment/paystack.tpl
+++ b/2.3.x/upload/catalog/view/theme/default/template/payment/paystack.tpl
@@ -16,6 +16,7 @@
       key: '<?php echo $key; ?>',
       email: '<?php echo $email; ?>',
       amount: <?php echo $amount; ?>,
+      currency: '<?php echo $currency; ?>',
       ref: '<?php echo $ref; ?>',
       callback: function(response){
           window.location.href='<?php echo html_entity_decode($callback); ?>';

--- a/2.x/upload/catalog/controller/payment/paystack.php
+++ b/2.x/upload/catalog/controller/payment/paystack.php
@@ -25,6 +25,7 @@ class ControllerPaymentPaystack extends Controller
             $data['ref'] = uniqid('' . $this->session->data['order_id'] . '-');
             $data['amount'] = intval($order_info['total'] * 100);
             $data['email'] = $order_info['email'];
+            $data['currency'] = $order_info['currency_code'];
             $data['callback'] = $this->url->link('payment/paystack/callback', 'trxref=' . rawurlencode($data['ref']), 'SSL');
 
             if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/payment/paystack.tpl')) {
@@ -43,59 +44,19 @@ class ControllerPaymentPaystack extends Controller
             $skey = $this->config->get('paystack_test_secret');
         }
 
-        $context = stream_context_create(array(
-            'http'=>array(
-              'method'=>"GET",
-              'header'=>"Authorization: Bearer " .  $skey,
+        $context = stream_context_create(
+            array(
+                'http'=>array(
+                'method'=>"GET",
+                'header'=>"Authorization: Bearer " .  $skey,
+                )
             )
-          )
         );
         $url = 'https://api.paystack.co/transaction/verify/'. rawurlencode($reference);
         $request = file_get_contents($url, false, $context);
         return json_decode($request, true);
     }
-    // protected function query_api_transaction_verify($reference)
-    // {
-    //     $url = 'https://api.paystack.co/transaction/verify/' . urlencode($reference);
-    //     $data = array();
-        
-    //     if ($this->config->get('paystack_live')) {
-    //         $skey = $this->config->get('paystack_live_secret');
-    //     } else {
-    //         $skey = $this->config->get('paystack_test_secret');
-    //     }
 
-    //     //open connection
-    //     $ch = curl_init();
-
-    //     //set the url, and the header
-    //     curl_setopt($ch, CURLOPT_URL, $url);
-    //     curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-
-    //     // Paystack's servers require TLSv1.2
-    //     // Force CURL to use this
-    //     if (!defined('CURL_SSLVERSION_TLSV1_2')) {
-    //         define('CURL_SSLVERSION_TLSV1_2', 6);
-    //     }
-    //     curl_setopt($ch, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSV1_2);
-
-    //     curl_setopt(
-    //         $ch, CURLOPT_HTTPHEADER, [
-    //         'Authorization: Bearer ' . $skey]
-    //     );
-
-    //     //execute post
-    //     $result = curl_exec($ch);
-
-    //     //close connection
-    //     curl_close($ch);
-
-    //     if ($result) {
-    //         $data = json_decode($result, true);
-    //     }
-        
-    //     return $data;
-    // }
     private function redir_and_die($url, $onlymeta = false)
     {
         if (!headers_sent() && !$onlymeta) {

--- a/2.x/upload/catalog/model/payment/paystack.php
+++ b/2.x/upload/catalog/model/payment/paystack.php
@@ -24,8 +24,12 @@ class ModelPaymentPaystack extends Model
             $status = false;
         }
 
-        // Paystack Only switches NGN for now
-        if ($status && (strtoupper($this->currency->getCode())!=='NGN')) {
+        // Paystack only switches NGN, GHS and USD for now
+        if ($status 
+            && ((strtoupper($this->currency->getCode())!=='NGN')
+            || (strtoupper($this->config->getCode())!=='GHS')
+            || (strtoupper($this->config->getCode())!=='USD'))
+        ) {
             $status = false;
         }
 

--- a/2.x/upload/catalog/view/theme/default/template/payment/paystack.tpl
+++ b/2.x/upload/catalog/view/theme/default/template/payment/paystack.tpl
@@ -16,6 +16,7 @@
       key: '<?php echo $key; ?>',
       email: '<?php echo $email; ?>',
       amount: <?php echo $amount; ?>,
+      currency: '<?php echo $currency; ?>',
       ref: '<?php echo $ref; ?>',
       callback: function(response){
           window.location.href='<?php echo html_entity_decode($callback); ?>';

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ Install to receive payments for your goods in naira from any Mastercard, Visa or
 - OpenSSL v1.0.1 or more recent
 
 ## Notes
-- Paystack currently only accepts the following currencies: `NGN`.
+- Paystack currently only accepts the following currencies: `NGN`, `GHS` and `USD`.
 - You need to have created an account on [paystack.com](https://dashboard.paystack.co/#/signup).
 
 ## Features:
 - Paystack payment gateway integration
-- Activates payment module only when cart currency is `NGN`
+- Activates payment module only when cart currency is `NGN`, `GHS` or `USD`.
 - Activate payment module only when order total reaches the amount you specified
 - Captures call back notification to automatically update order status
 - Simply turn on Live Mode to accept live payments.
@@ -30,7 +30,7 @@ Install to receive payments for your goods in naira from any Mastercard, Visa or
 5. Configure the module accordingly. 
  - To get your live and test secret keys, visit [the Paystack Dashboard](https://dashboard.paystack.co/#/settings/developer).
 6. Enable Paystack payment gateway on your OpenCart admin.
-7. Add and set NGN as your default store currency.
+7. Add and set NGN, GHS or USD. as your default store currency.
 8. Proceed to [Paystack OpenCart Extension](http://www.opencart.com/index.php?route=extension/extension/info&extension_id=25767&filter_search=paystack) to rate our work.
 
 ## Other Configuration


### PR DESCRIPTION
- Add currency parameter to initialization on Paystack Inline
- Add `GHS` and `USD` as accepted parameters on checking `$status` when listing Paystack as available gateway. Formerly, it only checks for when currency is `NGN`.
- Minor code refactor